### PR TITLE
feat: add craftengineer and obsidian garden gallery

### DIFF
--- a/README.md
+++ b/README.md
@@ -408,7 +408,7 @@ This curated list contains 95 awesome digital gardens that share the source of t
 - [Richard Litt's compilation](https://github.com/RichardLitt/meta-knowledge)
 - [KasperZutterman's compilation](https://github.com/KasperZutterman/Second-Brain)
 - [Webring](https://webring.xxiivv.com/)
-- [Obsidian Garden Gallery](https://jsifalda.link/Op0L31m)
+- [Obsidian Garden Gallery](https://obsidian-gallery.craftengineer.com/)
 
 Or the [digital garden](https://www.reddit.com/r/DigitalGardens/)'s reddit.
 

--- a/README.md
+++ b/README.md
@@ -403,11 +403,12 @@ This curated list contains 95 awesome digital gardens that share the source of t
 
 ## Related Resources
 
-* [Maggie Appleton's compilation](https://github.com/MaggieAppleton/digital-gardeners)
-* [Nikita's compilation](https://wiki.nikitavoloboev.xyz/other/wiki-workflow#similar-wikis-i-liked)
-* [Richard Litt's compilation](https://github.com/RichardLitt/meta-knowledge)
-* [KasperZutterman's compilation](https://github.com/KasperZutterman/Second-Brain)
-* [Webring](https://webring.xxiivv.com/)
+- [Maggie Appleton's compilation](https://github.com/MaggieAppleton/digital-gardeners)
+- [Nikita's compilation](https://wiki.nikitavoloboev.xyz/other/wiki-workflow#similar-wikis-i-liked)
+- [Richard Litt's compilation](https://github.com/RichardLitt/meta-knowledge)
+- [KasperZutterman's compilation](https://github.com/KasperZutterman/Second-Brain)
+- [Webring](https://webring.xxiivv.com/)
+- [Obsidian Garden Gallery](https://jsifalda.link/Op0L31m)
 
 Or the [digital garden](https://www.reddit.com/r/DigitalGardens/)'s reddit.
 

--- a/projects.yaml
+++ b/projects.yaml
@@ -25,14 +25,12 @@ categories:
     subtitle: ''
 
 labels:
-
   - label: activism
     image: https://raw.githubusercontent.com/lyz-code/best-of-digital-gardens/main/.icons/activism.png
   - label: antifascism
     image: https://raw.githubusercontent.com/lyz-code/best-of-digital-gardens/main/.icons/antifascism.png
   - label: feminism
     image: https://raw.githubusercontent.com/lyz-code/best-of-digital-gardens/main/.icons/feminism.png
-
 
   - label: programming
     image: https://raw.githubusercontent.com/lyz-code/best-of-digital-gardens/main/.icons/programming.png
@@ -54,10 +52,15 @@ labels:
     image: https://raw.githubusercontent.com/lyz-code/best-of-digital-gardens/main/.icons/science.png
 
 projects:
+  - name: Craft Engineer
+    homepage: https://craftengineer.com
+    labels: [programming, productivity, leadership, team management]
+    github_id: ''
+    description: 'Digital garden focused on engineering management, software development, and personal growth'
+    category: english
   - name: The Blue Book
     homepage: https://lyz-code.github.io/blue-book
-    labels: [activism, antifascism, productivity, health, programming, python, linux,
-      arts, science, feminism]
+    labels: [activism, antifascism, productivity, health, programming, python, linux, arts, science, feminism]
     github_id: lyz-code/blue-book
     description: ''
     category: english
@@ -561,13 +564,13 @@ projects:
     category: english
   - name: whoibrar notes
     homepage: https://notes.whoibrar.com/
-    labels: [productivity,programming,python]
+    labels: [productivity, programming, python]
     github_id: ''
     description: ''
     category: english
   - name: The Golden Forest
     homepage: https://www.lorien.cloud/
-    labels: [linux,tools]
+    labels: [linux, tools]
     github_id: 'sdelrio/golden-forest'
     description: ''
     category: english
@@ -631,4 +634,3 @@ projects:
     github_id: protrolium/gavart.ist
     description: Digital garden of a composer
     category: english
-    


### PR DESCRIPTION
This PR adds the Obsidian Gallery (https://obsidian-gallery.craftengineer.com/) to the Related Resources section, and also https://craftengineer.com/ into projects.