### PR TITLE
Add link to Obsidian Gallery

### DIFF
--- a/README.md
+++ b/README.md
@@ -411,6 +411,7 @@ This curated list contains 96 awesome digital gardens that share the source of t
 * [Richard Litt's compilation](https://github.com/RichardLitt/meta-knowledge)
 * [KasperZutterman's compilation](https://github.com/KasperZutterman/Second-Brain)
 * [Webring](https://webring.xxiivv.com/)
+* [Obsidian Garden Gallery](https://obsidian-gallery.craftengineer.com/)
 
 Or the [digital garden](https://www.reddit.com/r/DigitalGardens/)'s reddit.
 


### PR DESCRIPTION
Hello, unfortunately this change from this PR https://github.com/lyz-code/best-of-digital-gardens/pull/34 as not propagated, so hopefully now it shows on readme correctly 🙏 

thanks a lot in advance!